### PR TITLE
Don't send alt unless we really mean it.

### DIFF
--- a/xkeysnail/key.py
+++ b/xkeysnail/key.py
@@ -735,6 +735,9 @@ class Action(IntEnum):
     def is_pressed(self):
         return self == Action.PRESS or self == Action.REPEAT
 
+    def is_release(self):
+        return self == Action.RELEASE
+
 
 @unique
 class Modifier(Enum):


### PR DESCRIPTION
Currently Alt is pressed and released when it's activating a binding. Applications like
Firefox and all Microsoft applications (Noticed in a VM) show the application
menu when a Alt press and release is sent without another key in between. This
means that currently all M-* bindings are pretty much useless in these
applications.

This commit make's sure that we only send ALT when it's part of a binding thats intended to be sent to the application and not when it's a part of a binding that sends other keys that's not ALT. I also added a check that ensure that if ALT is physically pressed and released without another key
in between the press and release, then the ALT events are sent.