### PR TITLE
Add multipurpose key support

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -13,6 +13,19 @@ define_conditional_modmap(re.compile(r'Emacs'), {
     Key.RIGHT_CTRL: Key.ESC,
 })
 
+# [Multipurpose modmap] Give a key two meanings. A normal key when pressed and
+# released, and a modifier key when held down with another key. See Xcape,
+# Carabiner and caps2esc for ideas and concept.
+define_multipurpose_modmap(
+    # Enter is enter when pressed and released. Control when held down.
+    {Key.ENTER: [Key.ENTER, Key.RIGHT_CTRL]}
+
+    # Capslock is escape when pressed and released. Control when held down.
+    # {Key.CAPSLOCK: [Key.ESC, Key.LEFT_CTRL]
+    # To use this example, you can't remap capslock with define_modmap.
+)
+
+
 # Keybindings for Firefox/Chrome
 define_keymap(re.compile("Firefox|Google-chrome"), {
     # Ctrl+Alt+j/k to switch next/previous tab


### PR DESCRIPTION
Give a key two meanings. A normal key when pressed and a modifier key when held down down.
Checkout [xcape](https://github.com/alols/xcape) for an idea of the concept.
I personally remap caps to esc/ctrl and return to return/ctrl with [Interception Tools](https://gitlab.com/interception/linux/tools) but since i'm now also using xkeysnail i figured it would be nice to just use one keyboard remapping tool. My reason for remapping ret to ctrl is to avoid pain in my left hand that happens after long periods in emacs otherwise.