### PR TITLE
[Feature] device name in conditional modmap

### DIFF
--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -86,7 +86,7 @@ def loop(devices):
                     # device = devices[fd]
                     for event in device.read():
                         if event.type == ecodes.EV_KEY:
-                            on_event(event)
+                            on_event(event, device.name)
                         else:
                             send_event(event)
             except OSError as e:

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -250,7 +250,7 @@ def on_event(event, device_name):
     if _conditional_mod_map:
         wm_class = get_active_window_wm_class()
         for condition, mod_map in _conditional_mod_map:
-            if condition(wm_class):
+            if condition(wm_class, device_name):
                 active_mod_map = mod_map
                 break
     if active_mod_map and key in active_mod_map:

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from enum import Enum
+from inspect import signature
 from .key import Action, Combo, Key, Modifier
 from .output import send_combo, send_key_action, send_key
 
@@ -250,7 +251,11 @@ def on_event(event, device_name):
     if _conditional_mod_map:
         wm_class = get_active_window_wm_class()
         for condition, mod_map in _conditional_mod_map:
-            if condition(wm_class, device_name):
+            params = [wm_class]
+            if len(signature(condition).parameters) == 2:
+                params = [wm_class, device_name]
+
+            if condition(*params):
                 active_mod_map = mod_map
                 break
     if active_mod_map and key in active_mod_map:

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -241,7 +241,7 @@ def multipurpose_handler(key, action):
         _last_key_press = key
 
 
-def on_event(event):
+def on_event(event, device_name):
     key = Key(event.code)
     action = Action(event.value)
     wm_class = None


### PR DESCRIPTION
I want to change modmap according to device like below.
```python
define_conditional_modmap(lambda wm_class, device_name: device_name not in ("ErgoDox EZ ErgoDox EZ"),{
    Key.CAPSLOCK: Key.TAB,
    Key.LEFT_ALT: Key.LEFT_CTRL,
    Key.RIGHT_ALT: Key.RIGHT_CTRL,
    Key.SYSRQ: Key.RIGHT_ALT,
    Key.LEFT_META: Key.LEFT_ALT,
    Key.RIGHT_META: Key.RIGHT_ALT,
})


## common configurations in each devices
...
```

Though I think this is accomplished to starting xkeysnail per each device, I can reuse `config.py` by changing modmap by device.

```
sudo xkeysnail builtin_keyboard_config.py --device /dev/input/event0
sudo xkeysnail config.py --device /dev/input/event18
```