### PR TITLE
feat: add -q / --quiet option to suppress output of key events

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to specify keyboard devices, use `--devices` option:
 
 If you have hot-plugging keyboards, use `--watch` option.
 
+If you want to suppress output of key events, use `-q` / `--quiet` option especially when running as a daemon.
+
 ## How to prepare `config.py`?
 
 (**If you just need Emacs-like keybindings, consider to

--- a/xkeysnail/__init__.py
+++ b/xkeysnail/__init__.py
@@ -30,6 +30,8 @@ def cli_main():
                         help='keyboard devices to remap (if omitted, xkeysnail choose proper keyboard devices)')
     parser.add_argument('--watch', dest='watch', action='store_true',
                         help='watch keyboard devices plug in ')
+    parser.add_argument('-q', '--quiet', dest='quiet', action='store_true',
+                        help='suppress output of key events')
     args = parser.parse_args()
 
     # Make sure that user have root privilege
@@ -47,4 +49,4 @@ Make sure that you have executed xkeysnail with root privilege such as
 
     # Enter event loop
     from xkeysnail.input import loop
-    loop(args.devices, args.watch)
+    loop(args.devices, args.watch, args.quiet)

--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -92,7 +92,7 @@ def in_device_list(fn, devices):
             return True
     return False
 
-def loop(device_matches, device_watch):
+def loop(device_matches, device_watch, quiet):
     devices = select_device(device_matches, True)
     try:
         for device in devices:
@@ -106,6 +106,8 @@ def loop(device_matches, device_watch):
         inotify.add_watch("/dev/input", flags.CREATE)
         print("Watching keyboard devices plug in")
     device_filter = DeviceFilter(device_matches)
+    if quiet:
+        print("No key event will be output since quiet option was specified.")
     try:
         while True:
             try:
@@ -117,7 +119,7 @@ def loop(device_matches, device_watch):
                     if isinstance(waitable, InputDevice):
                         for event in waitable.read():
                             if event.type == ecodes.EV_KEY:
-                                on_event(event, waitable.name)
+                                on_event(event, waitable.name, quiet)
                             else:
                                 send_event(event)
                     else:

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -258,7 +258,7 @@ def multipurpose_handler(key, action):
         _last_key = key
 
 
-def on_event(event, device_name):
+def on_event(event, device_name, quiet):
     key = Key(event.code)
     action = Action(event.value)
     wm_class = None
@@ -282,20 +282,20 @@ def on_event(event, device_name):
         if key in _multipurpose_map:
             return
 
-    on_key(key, action, wm_class=wm_class)
+    on_key(key, action, wm_class=wm_class, quiet=quiet)
 
 
-def on_key(key, action, wm_class=None):
+def on_key(key, action, wm_class=None, quiet=False):
     if key in Modifier.get_all_keys():
         update_pressed_modifier_keys(key, action)
         send_key_action(key, action)
     elif not action.is_pressed():
         send_key_action(key, action)
     else:
-        transform_key(key, action, wm_class=wm_class)
+        transform_key(key, action, wm_class=wm_class, quiet=quiet)
 
 
-def transform_key(key, action, wm_class=None):
+def transform_key(key, action, wm_class=None, quiet=False):
     global _mode_maps
     global _toplevel_keymaps
 
@@ -321,9 +321,11 @@ def transform_key(key, action, wm_class=None):
                or condition is None:
                 _mode_maps.append(mappings)
                 keymap_names.append(name)
-        print("WM_CLASS '{}' | active keymaps = [{}]".format(wm_class, ", ".join(keymap_names)))
+        if not quiet:
+            print("WM_CLASS '{}' | active keymaps = [{}]".format(wm_class, ", ".join(keymap_names)))
 
-    print(combo)
+    if not quiet:
+        print(combo)
 
     # _mode_maps: [global_map, local_1, local_2, ...]
     for mappings in _mode_maps:


### PR DESCRIPTION
Quick implementation of `--quiet` without touching the fundamental of logging.

Closes: #26 