### PR TITLE
Allow capslock as a modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Key specification in a keymap is in a form of `K("(<Modifier>-)*<Key>")` where
 - `M` or `Alt` -> Alt key
 - `Shift` -> Shift key
 - `Super` or `Win` -> Super/Windows key
+- `Caps` -> Capslock key
 
 and `<Key>` is a key whose name is defined
 in [`key.py`](https://github.com/mooz/xkeysnail/blob/master/xkeysnail/key.py).

--- a/xkeysnail/key.py
+++ b/xkeysnail/key.py
@@ -739,7 +739,7 @@ class Action(IntEnum):
 @unique
 class Modifier(Enum):
 
-    CONTROL, ALT, SHIFT, SUPER = range(4)
+    CONTROL, ALT, SHIFT, SUPER, CAPS = range(5)
 
     @classmethod
     def _get_modifier_map(cls):
@@ -747,7 +747,8 @@ class Modifier(Enum):
             cls.CONTROL: {Key.LEFT_CTRL, Key.RIGHT_CTRL},
             cls.ALT: {Key.LEFT_ALT, Key.RIGHT_ALT},
             cls.SHIFT: {Key.LEFT_SHIFT, Key.RIGHT_SHIFT},
-            cls.SUPER: {Key.LEFT_META, Key.RIGHT_META}
+            cls.SUPER: {Key.LEFT_META, Key.RIGHT_META},
+            cls.CAPS: {Key.CAPSLOCK}
         }
 
     def __str__(self):
@@ -755,6 +756,7 @@ class Modifier(Enum):
         if self.value == self.ALT.value: return "M"
         if self.value == self.SHIFT.value: return "Shift"
         if self.value == self.SUPER.value: return "Super"
+        if self.value == self.CAPS.value: return "Caps"
         return None
 
     def get_keys(self):

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -112,7 +112,7 @@ def K(exp):
     import re
     modifier_strs = []
     while True:
-        m = re.match(r"\A(C|Ctrl|M|Alt|Shift|Super|Win)-", exp)
+        m = re.match(r"\A(C|Ctrl|M|Alt|Shift|Super|Win|Caps)-", exp)
         if m is None:
             break
         modifier = m.group(1)
@@ -134,6 +134,8 @@ def create_modifiers_from_strings(modifier_strs):
             pass
         elif modifier_str == 'Shift':
             modifiers.add(Modifier.SHIFT)
+        elif modifier_str == 'Caps':
+            modifiers.add(Modifier.CAPS)
     return modifiers
 
 # ============================================================


### PR DESCRIPTION
Thanks for this great work!

In some apps, I want to use capslock as a modifier.
I have some settings in `/etc/X11/xorg.d/` so I don't want to use `define_modmap`.