### PR TITLE
Add KeyboardInterrupt exception handler

### DIFF
--- a/xkeysnail/__init__.py
+++ b/xkeysnail/__init__.py
@@ -5,6 +5,7 @@ def eval_file(path):
     with open(path, "rb") as file:
         exec(compile(file.read(), path, 'exec'), globals())
 
+
 def uinput_device_exists():
     from os.path import exists
     return exists('/dev/uinput')

--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -146,6 +146,9 @@ def loop(device_matches, device_watch, quiet):
                 if isinstance(waitable, InputDevice):
                     print("Device removed: " + str(waitable.name))
                     devices.remove(waitable)
+            except KeyboardInterrupt:
+                print("Received an interrupt, exiting.")
+                break
     finally:
         for device in devices:
             device.ungrab()


### PR DESCRIPTION
When the user interrupts the program a informational message is printed instead of a Python stack trace.
Also fix one flake8 error.