### PR TITLE
Avoid releasing keys that were never considered pressed by the system

### DIFF
--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -38,18 +38,24 @@ def send_key_action(key, action):
 def send_combo(combo):
 
     released_modifiers_keys = []
-    for modifier in set(Modifier) - combo.modifiers:
-        for modifier_key in modifier.get_keys():
-            if modifier_key in _pressed_modifier_keys:
-                send_key_action(modifier_key, Action.RELEASE)
-                released_modifiers_keys.append(modifier_key)
+
+    extra_modifier_keys = _pressed_modifier_keys.copy()
+    missing_modifiers = combo.modifiers.copy()
+    for pressed_key in _pressed_modifier_keys:
+        for modifier in combo.modifiers:
+            if pressed_key in modifier.get_keys():
+                extra_modifier_keys.remove(pressed_key)
+                missing_modifiers.remove(modifier)
+
+    for modifier_key in extra_modifier_keys:
+        send_key_action(modifier_key, Action.RELEASE)
+        released_modifiers_keys.append(modifier_key)
 
     pressed_modifier_keys = []
-    for modifier in combo.modifiers:
-        if not any(modifier_key in _pressed_modifier_keys for modifier_key in modifier.get_keys()):
-            modifier_key = modifier.get_key()
-            send_key_action(modifier_key, Action.PRESS)
-            pressed_modifier_keys.append(modifier_key)
+    for modifier in missing_modifiers:
+        modifier_key = modifier.get_key()
+        send_key_action(modifier_key, Action.PRESS)
+        pressed_modifier_keys.append(modifier_key)
 
     send_key_action(combo.key, Action.PRESS)
 

--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -10,7 +10,7 @@ __author__ = 'zh'
 _uinput = UInput()
 
 _pressed_modifier_keys = set()
-
+_pressed_keys = set()
 
 def update_modifier_key_pressed(key, action):
     if key in Modifier.get_all_keys():
@@ -19,6 +19,14 @@ def update_modifier_key_pressed(key, action):
         else:
             _pressed_modifier_keys.discard(key)
 
+def update_pressed_keys(key, action):
+    if action.is_pressed():
+        _pressed_keys.add(key)
+    else:
+        _pressed_keys.discard(key)
+
+def is_pressed(key):
+    return key in _pressed_keys
 
 def send_sync():
     _uinput.syn()
@@ -31,6 +39,7 @@ def send_event(event):
 
 def send_key_action(key, action):
     update_modifier_key_pressed(key, action)
+    update_pressed_keys(key, action)
     _uinput.write(ecodes.EV_KEY, key, action)
     send_sync()
 

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -3,7 +3,7 @@
 import itertools
 from inspect import signature
 from .key import Action, Combo, Key, Modifier
-from .output import send_combo, send_key_action, send_key
+from .output import send_combo, send_key_action, send_key, is_pressed
 
 __author__ = 'zh'
 
@@ -369,7 +369,8 @@ def on_key(key, action, wm_class=None, quiet=False):
         update_pressed_modifier_keys(key, action)
         send_key_action(key, action)
     elif not action.is_pressed():
-        send_key_action(key, action)
+        if is_pressed(key):
+            send_key_action(key, action)
     else:
         transform_key(key, action, wm_class=wm_class, quiet=quiet)
 


### PR DESCRIPTION
This is two commits to fix two similar issues with RELEASE being set for keys that were never pressed as far as the system is concerned.
For modifiers, this was causing issues setting shortcuts in VS Code and triggering IntelliJ's double-tap modifier shortcuts.
For other keys I did not run into any problems caused by this, but it seemed inappropriate.