### PR TITLE
enable --watch to watch permission change

### DIFF
--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -109,7 +109,7 @@ def loop(device_matches, device_watch, quiet):
     if device_watch:
         from inotify_simple import INotify, flags
         inotify = INotify()
-        inotify.add_watch("/dev/input", flags.CREATE)
+        inotify.add_watch("/dev/input", flags.CREATE | flags.ATTRIB)
         print("Watching keyboard devices plug in")
     device_filter = DeviceFilter(device_matches)
 


### PR DESCRIPTION
Added ATTRIB flag to inotify so that it can watch permission change of device.
It can solve the problem that xkeysnail fails to reconnect to device when it tries to access the device before the proper permission is set.

See the comment of @kentacho in issue #44