### PR TITLE
Add define_conditional_multipurpose_modmap

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -25,6 +25,18 @@ define_multipurpose_modmap(
     # To use this example, you can't remap capslock with define_modmap.
 )
 
+# [Conditional multipurpose modmap] Multipurpose modmap in certain conditions,
+# such as for a particular device.
+define_conditional_multipurpose_modmap(lambda wm_class, device_name: device_name.startswith("Microsoft"), {
+   # Left shift is open paren when pressed and released.
+   # Left shift when held down.
+   Key.LEFT_SHIFT: [Key.KPLEFTPAREN, Key.LEFT_SHIFT],
+
+   # Right shift is close paren when pressed and released.
+   # Right shift when held down.
+   Key.RIGHT_SHIFT: [Key.KPRIGHTPAREN, Key.RIGHT_SHIFT]
+})
+
 
 # Keybindings for Firefox/Chrome
 define_keymap(re.compile("Firefox|Google-chrome"), {


### PR DESCRIPTION
As with `define_conditional_modmap`, this lets you apply the remapping according to device name.

For example:

```
# [Multipurpose modmap] Give a key two meanings. A normal key when pressed and
# released, and a modifier key when held down with another key.
define_conditional_multipurpose_modmap(lambda wm_class, device_name: device_name.startswith("Microsoft"), {
   # Capslock is tab when pressed and released.
   # Control when held down.
   Key.CAPSLOCK: [Key.TAB, Key.LEFT_CTRL],

   # Tab is grave when pressed and released.
   # Win/Super when held down.
   Key.TAB: [Key.GRAVE, Key.LEFT_META],

   # Left shift is open paren when pressed and released.
   # Left shift when held down.
   Key.LEFT_SHIFT: [Key.KPLEFTPAREN, Key.LEFT_SHIFT],

   # Right shift is close paren when pressed and released.
   # Right shift when held down.
   Key.RIGHT_SHIFT: [Key.KPRIGHTPAREN, Key.RIGHT_SHIFT]
})
```

Fixes #51 
