### PR TITLE
fix conditional_multipurpose_modmap and add timeout

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -3,6 +3,9 @@
 import re
 from xkeysnail.transform import *
 
+# define timeout for multipurpose_modmap
+define_timeout(1)
+
 # [Global modemap] Change modifier keys as in xmodmap
 define_modmap({
     Key.CAPSLOCK: Key.LEFT_CTRL

--- a/example/config.py
+++ b/example/config.py
@@ -25,6 +25,18 @@ define_multipurpose_modmap(
     # To use this example, you can't remap capslock with define_modmap.
 )
 
+# [Conditional multipurpose modmap] Multipurpose modmap in certain conditions,
+# such as for a particular device.
+define_conditional_multipurpose_modmap(lambda wm_class, device_name: device_name.startswith("Microsoft"), {
+   # Left shift is open paren when pressed and released.
+   # Left shift when held down.
+   Key.LEFT_SHIFT: [Key.KPLEFTPAREN, Key.LEFT_SHIFT],
+
+   # Right shift is close paren when pressed and released.
+   # Right shift when held down.
+   Key.RIGHT_SHIFT: [Key.KPRIGHTPAREN, Key.RIGHT_SHIFT]
+})
+
 
 # Keybindings for Firefox/Chrome
 define_keymap(re.compile("Firefox|Google-chrome"), {

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -347,6 +347,9 @@ def multipurpose_handler(multipurpose_map, key, action):
                 on_key(mod_key, Action.RELEASE)
         elif action == Action.PRESS and not key_is_down:
             set_key_state(Action.PRESS)
+        elif action == Action.RELEASE:
+            update_pressed_modifier_keys(key, action)
+            send_key_action(key, action)
     # if key is not a multipurpose or mod key we want eventual modifiers down
     elif (key not in Modifier.get_all_keys()) and action == Action.PRESS:
         maybe_press_modifiers(multipurpose_map)


### PR DESCRIPTION
some fix for: https://github.com/mooz/xkeysnail/pull/52

Resolving conflicts of conditional_multipurpose_modmap when switching windows.

A window switch when a key is pressed will cause an error in the key state. Use a globally unified key state for recording to solve this problem.