### PR TITLE
Don't exit when there is only one device that gets unplugged.

### DIFF
--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -140,8 +140,6 @@ def loop(device_matches, device_watch, quiet):
                 if isinstance(waitable, InputDevice):
                     remove_device(devices, waitable)
                     print("Device removed: " + str(device.name))
-                    if not len(devices):
-                        break
             except KeyboardInterrupt:
                 print("Received an interrupt, exiting.")
                 break


### PR DESCRIPTION
If you have two keyboards and you unplug/replug one, xkeysnail keeps
running. Why should it be any different if you have one keyboard and
unplug/replug?

The current behaviour is annoying, particularly if you have a keyboard
with flashable firmware (e.g. QMK), as xkeysnail would exit whenever you
flashed an update or otherwise reset the board.