### PR TITLE
Persistent modifiers on partial release of modifier combo. Fixes #74

### DIFF
--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -76,11 +76,15 @@ def send_combo(combo):
     for modifier in missing_modifiers:
         modifier_key = modifier.get_key()
         send_key_action(modifier_key, Action.PRESS)
-        pressed_modifier_keys.append(modifier_key)
 
     send_key_action(combo.key, Action.PRESS)
 
     send_key_action(combo.key, Action.RELEASE)
+
+    # Release modifiers that are not physically held - ONLY
+    for modifier in missing_modifiers:
+        modifier_key = modifier.get_key()
+        send_key_action(modifier_key, Action.RELEASE)
 
     for modifier in reversed(released_modifiers_keys):
         send_key_action(modifier, Action.PRESS)

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -427,8 +427,10 @@ def on_key(key, action, wm_class=None, quiet=False):
         # is released
         if str(key) != "Key.LEFT_SHIFT" and str(key) != "Key.RIGHT_SHIFT":
             for output_key in output_mods:
-                update_pressed_modifier_keys(output_key, action)
-                send_key_action(output_key, action)
+                # Release modifiers that are not physically held - ONLY
+                if not is_pressed(output_key):
+                    update_pressed_modifier_keys(output_key, action)
+                    send_key_action(output_key, action)
     elif not action.is_pressed():
         if is_pressed(key):
             send_key_action(key, action)

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -425,12 +425,11 @@ def on_key(key, action, wm_class=None, quiet=False):
         send_key_action(key, action)
         # Release mapped modifier only when physical mod
         # is released
-        if str(key) != "Key.LEFT_SHIFT" and str(key) != "Key.RIGHT_SHIFT":
-            for output_key in output_mods:
-                # Release modifiers that are not physically held - ONLY
-                if not is_pressed(output_key):
-                    update_pressed_modifier_keys(output_key, action)
-                    send_key_action(output_key, action)
+        for output_key in output_mods:
+            # Release modifiers that are not physically held - ONLY
+            if not is_pressed(output_key):
+                update_pressed_modifier_keys(output_key, action)
+                send_key_action(output_key, action)
     elif not action.is_pressed():
         if is_pressed(key):
             send_key_action(key, action)


### PR DESCRIPTION
Apparently this issue has existed going back to even May 2019, and my changes to the on release behavior of modifier keys had kept that original behavior. It has been resolved now by checking the actual key released against the possible modifiers to be released. Newly mapped modifiers are released separately (also known as missing modifiers in output.py).

Original commit 8c4fadb introduced the bug, while fixing similar modifier key behaviors.

More info in the thread. https://github.com/mooz/xkeysnail/issues/74