### PR TITLE
Use XDG Base Directory for config file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name             = "xkeysnail",
       packages         = ["xkeysnail"],
       scripts          = ["bin/xkeysnail"],
       license          = "GPL",
-      install_requires = ["evdev", "python-xlib", "inotify_simple"]
+      install_requires = ["evdev", "python-xlib", "inotify_simple", "appdirs"]
       )

--- a/xkeysnail/__init__.py
+++ b/xkeysnail/__init__.py
@@ -29,8 +29,9 @@ def cli_main():
 
     # Parse args
     import argparse
+    from appdirs import user_config_dir
     parser = argparse.ArgumentParser(description='Yet another keyboard remapping tool for X environment.')
-    parser.add_argument('config', metavar='config.py', type=str,
+    parser.add_argument('config', metavar='config.py', type=str, default=user_config_dir('xkeysnail/config.py'), nargs='?',
                         help='configuration file (See README.md for syntax)')
     parser.add_argument('--devices', dest="devices", metavar='device', type=str, nargs='+',
                         help='keyboard devices to remap (if omitted, xkeysnail choose proper keyboard devices)')


### PR DESCRIPTION
This will look for the config file in `XDG_CONFIG_HOME` if the argument is omitted, so it follows the [XDG Base Directory](https://wiki.archlinux.org/index.php/XDG_Base_Directory) specification for user specific configurations. Make sure to `sudo -E xkeysnail` to preserve the user environment.