### PR TITLE
Don't expose uinput device as joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If you have hot-plugging keyboards, use `--watch` option.
 
 If you want to suppress output of key events, use `-q` / `--quiet` option especially when running as a daemon.
 
+Remapping `BTN_` events (such as mouse clicks) is not supported with wayland compositors.
+
 ## How to prepare `config.py`?
 
 (**If you just need Emacs-like keybindings, consider to

--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 from evdev import ecodes
 from evdev.uinput import UInput
 from .key import Action, Combo, Modifier
@@ -7,7 +8,11 @@ from .key import Action, Combo, Modifier
 __author__ = 'zh'
 
 
-_uinput = UInput()
+if 'WAYLAND_DISPLAY' in os.environ:
+    _keyboard_codes = ecodes.keys.keys() - ecodes.BTN
+    _uinput = UInput(events={ecodes.EV_KEY: _keyboard_codes})
+else:
+    _uinput = UInput()
 
 _pressed_modifier_keys = set()
 _pressed_keys = set()


### PR DESCRIPTION
I use Fedora 32 with `sway` wayland wm. After recent `libinput` update (from `1.15.4` to `1.15.902`) my keyboard stopped working, unless I disabled `xkeysnail`.

`libinput` is used by sway and all most popular wayland compositors. It always had logic to ignore joysticks, but due to a bug the joystick check didn't work correctly. It was [fixed recently](https://gitlab.freedesktop.org/libinput/libinput/-/commit/b9ec408872cc4764d404d7b9057802ae476266bc). Unfortunately, `xkeysnail` uinput device is detected as joystick by udev and as a result `xkeysnail` events are ignored by latest `libinput`:

```
$ udevadm info /dev/input/event20
P: /devices/virtual/input/input23/event20
N: input/event20
L: 0
E: DEVPATH=/devices/virtual/input/input23/event20
E: DEVNAME=/dev/input/event20
E: MAJOR=13
E: MINOR=84
E: SUBSYSTEM=input
E: USEC_INITIALIZED=55911717
E: ID_INPUT=1
E: ID_INPUT_JOYSTICK=1
E: ID_INPUT_KEY=1
E: ID_INPUT_KEYBOARD=1
E: ID_SERIAL=noserial
E: LIBINPUT_DEVICE_GROUP=0/0/0:py-evdev-uinput
E: TAGS=:seat:power-switch:uaccess:
```

(note `ID_INPUT_JOYSTICK`).

Udev's joystick detection seems to rely on checking which events are requested during uinput device setup. I noticed almost all `BTN_` events trigger joystick tag, so as a fix I disabled them all in `xkeysnail` - but only if wayland compositor is present.