### PR TITLE
Disable joystick buttons, but not mouse buttons, enable mouse

### DIFF
--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -7,7 +7,29 @@ from .key import Action, Combo, Modifier
 __author__ = 'zh'
 
 
-_uinput = UInput()
+# Remove all buttons so udev doesn't think xkeysnail is a joystick
+_keyboard_codes = ecodes.keys.keys() - ecodes.BTN
+
+# But we want mouse buttons, so let's enumerate those and add them
+# back into the set of buttons we'll watch and use
+mouse_btns = {256: ['BTN_0', 'BTN_MISC'],
+              257: 'BTN_1',
+              258: 'BTN_2',
+              259: 'BTN_3',
+              260: 'BTN_4',
+              261: 'BTN_5',
+              262: 'BTN_6',
+              263: 'BTN_7',
+              264: 'BTN_8',
+              265: 'BTN_9',
+              272: ['BTN_LEFT', 'BTN_MOUSE'],
+              274: 'BTN_MIDDLE',
+              273: 'BTN_RIGHT'}
+_keyboard_codes.update(mouse_btns)
+
+_uinput = UInput(events={ecodes.EV_KEY: _keyboard_codes,
+                         ecodes.EV_REL: set([0,1,6,8,9]),
+                         })
 
 _pressed_modifier_keys = set()
 _pressed_keys = set()


### PR DESCRIPTION
Address the libinput 1.16+ incompatibility by disabling joystick buttons, but not mouse buttons.  This patch takes care of the joystick issue without breaking mouse buttons.  That restores functionality that the libinput problem broke.  This patch also enables mouse movement (e.g. the trackpoint or mouse built in to an external keyboard), which was not previously present, but seems to go well with the mouse button stuff and is only one additional line of code.


Note that this is a refinement on [PR 98](https://github.com/mooz/xkeysnail/pull/98).