### PR TITLE
Introduce variables

### DIFF
--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -106,6 +106,27 @@ def with_or_set_mark(combo):
 
     return _with_or_set_mark
 
+# ============================================================ #
+# Variable functions
+# ============================================================ #
+_var_dict = {};
+
+def set_var(k,v,ms=None):
+    def _set_var():
+        global _mark_set; global _var_dict
+        if ms != None: _mark_set=ms
+        _var_dict[k]=v
+    return _set_var
+
+def if_var(k,a,b,ms=None,v=False):
+    def _if_var():
+        global _mark_set; global _var_dict
+        if ms != None: _mark_set=ms
+        if _var_dict.get(k):
+            _var_dict[k]=v
+            return a
+        return b
+    return _if_var
 
 # ============================================================ #
 # Utility functions for keymap


### PR DESCRIPTION
This PR introduces variable set and test functions into transform. It also takes an argument to optionally modify the `mark`.

Actually I was planning to modify the `mark` like this: `[K("F3"), set_var("aa", True), set_mark(False)]`. However
I've never managed to get it working properly.

Here is an example to emulate Emacs `isearch` functionality in XKeysnail with variables.
```
K("C-s"): [K("F3"), set_var("aa", True, False)],
K("C-r"): [K("Shift-F3"), set_var("aa", True, False)],
K("C-g"): [K("esc"), set_var("aa", False, False)],
K("enter"): if_var("aa", K("esc"), K("enter"), False)
```