### PR TITLE
Permit keymap conditions to test against wm_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ application and takes one of the following forms:
 - Regular expression (e.g., `re.compile("YYY")`)
     - Activates the `mappings` if the pattern `YYY` matches the `WM_CLASS` of the application.
     - Case Insensitivity matching against `WM_CLASS` via `re.IGNORECASE` (e.g. `re.compile('Gnome-terminal', re.IGNORECASE)`)
-- `lambda wm_class: some_condition(wm_class)`
-    - Activates the `mappings` if the `WM_CLASS` of the application satisfies the condition specified by the `lambda` function.
-    - Case Insensitivity matching via `casefold()` or `lambda wm_class: wm_class.casefold()` (see example below to see how to compare to a list of names)
+- Lambda based condition utilizing `WM_CLASS`, device name, and `WM_NAME`. The lambda may have 1, 2, or 3 arguments, e.g:
+    - `lambda wm_class: some_condition(...)`
+    - `lambda wm_class, device_name : some_condition(...)`
+    - `lambda wm_class, device_name, wm_name: some_condition(...)`
+    - Activates the `mappings` if the specified by the `lambda` function is satisfied.
+    - For example: case-insensitivity matching via `lambda wm_class: wm_class.casefold()` (see example below to see how to compare to a list of names)
 - `None`: Refers to no condition. `None`-specified keymap will be a global keymap and is always enabled.
 
 Argument `mappings` is a dictionary in the form of `{key: command, key2:

--- a/example/config.py
+++ b/example/config.py
@@ -40,6 +40,13 @@ define_conditional_multipurpose_modmap(lambda wm_class, device_name: device_name
    Key.RIGHT_SHIFT: [Key.KPRIGHTPAREN, Key.RIGHT_SHIFT]
 })
 
+# Example keymap conditional on window name.
+# Google Docs / Sheets browser applications use M-slash as an execute-extended-command binding
+# Let's make it more emacsish
+define_keymap(lambda wm_class, device_name, wm_name: any(app in wm_name for app in ["Google Docs", "Google Sheets"]), {
+    K("M-x"): K("M-slash")
+}, "Google Suite")
+
 
 # Keybindings for Firefox/Chrome
 define_keymap(re.compile("Firefox|Google-chrome"), {

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -477,7 +477,7 @@ def transform_key(key, action, device_name=None, wm_class=None, wm_name=None, qu
                 _mode_maps.append(mappings)
                 keymap_names.append(name)
         if not quiet:
-            print("WM_CLASS '{}' WM_NAME '{}' | active keymaps = [{}]".format(wm_class, wm_name, ", ".join(keymap_names)))
+            print("WM_CLASS '{}' WM_NAME '{}' DEVICE_NAME '{}'| active keymaps = [{}]".format(wm_class, wm_name, device_name, ", ".join(keymap_names)))
 
     if not quiet:
         print(combo)


### PR DESCRIPTION
This allows bindings such as:

```
define_keymap(lambda wm_class, device_name, wm_name: "Google Docs" in wm_name, {
    # Google Docs uses M-slash as an execute-extended-command binding, let's make it more emacsish
    K("M-x"): K("M-slash")
})
```

Notes:

* Xlib built-in get_wm_name function doesn't support UTF-8 window names, so we use a custom function. Thanks to https://github.com/yoshinari-nomura/xkeysnail/commit/2a74e002a5c43fd757b91fee753d02b38782df36

* Keymap condition testing still looks at the number of args expected, and additionally passes `wm_name` if the number of args is 3 respectively. It's a bit ugly, but maintains backward compatibility for anyone already using the two argument version. This signature based condition testing was previously only used in the conditional modmap testing, now it is in global keymap testing in `transform`, so conditions using device and window name should also work there.

Fixes #122
