### PR TITLE
Add custom key delay.

### DIFF
--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import time
 from evdev import ecodes
 from evdev.uinput import UInput
 from .key import Action, Combo, Modifier
@@ -34,6 +35,12 @@ _uinput = UInput(events={ecodes.EV_KEY: _keyboard_codes,
 _pressed_modifier_keys = set()
 _pressed_keys = set()
 
+_key_delay_seconds = 0
+
+def set_key_delay(seconds):
+    global _key_delay_seconds
+    _key_delay_seconds = seconds
+
 def update_modifier_key_pressed(key, action):
     if key in Modifier.get_all_keys():
         if action.is_pressed():
@@ -64,6 +71,8 @@ def send_key_action(key, action):
     update_pressed_keys(key, action)
     _uinput.write(ecodes.EV_KEY, key, action)
     send_sync()
+    if _key_delay_seconds > 0:
+        time.sleep(_key_delay_seconds)
 
 
 def send_combo(combo):

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -4,7 +4,7 @@ import itertools
 from time import time
 from inspect import signature
 from .key import Action, Combo, Key, Modifier
-from .output import send_combo, send_key_action, send_key, is_pressed
+from .output import send_combo, send_key_action, send_key, is_pressed, set_key_delay
 
 __author__ = 'zh'
 
@@ -268,6 +268,11 @@ def define_timeout(seconds=1):
     global _timeout
     _timeout = seconds
 
+
+def define_key_delay(seconds):
+  """Defines a custom delay between each key event.
+  The argument is a floating point number for subsecond precision."""
+  set_key_delay(seconds)
 
 
 def define_modmap(mod_remappings):


### PR DESCRIPTION
I was having issue with IntelliJ where sometimes IntelliJ would do nothing when I type a key combo, adding a custom delay (1ms, `define_key_delay(0.001)`) between each key event has made the problem go away, even though I'm not entirely sure if this is a proper fix.