### PR TITLE
Interleave pressing/releasing of modifier keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,6 @@ define_conditional_modmap(re.compile(termStr, re.IGNORECASE), {
 })
 ```
 
-## FAQ
-
-### How do I fix Firefox capturing Alt before xkeysnail?
-
-In the Firefox location bar, go to `about:config`, search for `ui.key.menuAccessKeyFocuses`, and set the Value to `false`.
-
-
 ## License
 
 `xkeysnail` is distributed under GPL.

--- a/xkeysnail/output.py
+++ b/xkeysnail/output.py
@@ -78,25 +78,25 @@ def send_combo(combo):
                 extra_modifier_keys.remove(pressed_key)
                 missing_modifiers.remove(modifier)
 
-    for modifier_key in extra_modifier_keys:
-        send_key_action(modifier_key, Action.RELEASE)
-        released_modifiers_keys.append(modifier_key)
-
     pressed_modifier_keys = []
     for modifier in missing_modifiers:
         modifier_key = modifier.get_key()
         send_key_action(modifier_key, Action.PRESS)
         pressed_modifier_keys.append(modifier_key)
 
+    for modifier_key in extra_modifier_keys:
+        send_key_action(modifier_key, Action.RELEASE)
+        released_modifiers_keys.append(modifier_key)
+
     send_key_action(combo.key, Action.PRESS)
 
     send_key_action(combo.key, Action.RELEASE)
 
-    for modifier in reversed(pressed_modifier_keys):
-        send_key_action(modifier, Action.RELEASE)
-
     for modifier in reversed(released_modifiers_keys):
         send_key_action(modifier, Action.PRESS)
+
+    for modifier in reversed(pressed_modifier_keys):
+        send_key_action(modifier, Action.RELEASE)
 
 
 def send_key(key):


### PR DESCRIPTION
Fixes #43, fixes #82, by pressing new modifier keys before releasing the old ones to avoid triggering actions in applications that recognize the old keys.

For example, if we bind <kbd>alt+f</kbd> to <kbd>ctrl+right</kbd>, before this change, the following key sequence is generated with <kbd>alt+f</kbd> :

```
(user)       send Key.LEFT_ALT   Action.PRESS
(xkeysnail)  send Key.LEFT_ALT   Action.RELEASE
(xkeysnail)  send Key.RIGHT_CTRL Action.PRESS
(xkeysnail)  send Key.RIGHT      Action.PRESS
(xkeysnail)  send Key.RIGHT      Action.RELEASE
(xkeysnail)  send Key.RIGHT_CTRL Action.RELEASE
(xkeysnail)  send Key.LEFT_ALT   Action.PRESS
(user)       send Key.LEFT_ALT   Action.RELEASE
```

The press + release of the alt key (both at the start and end of the sequence) is what's causing apps like Firefox to show/focus the menu.

After this change, the following key sequence is generated with <kbd>alt+f</kbd>:

```
(user)       send Key.LEFT_ALT   Action.PRESS
(xkeysnail)  send Key.RIGHT_CTRL Action.PRESS
(xkeysnail)  send Key.LEFT_ALT   Action.RELEASE
(xkeysnail)  send Key.RIGHT      Action.PRESS
(xkeysnail)  send Key.RIGHT      Action.RELEASE
(xkeysnail)  send Key.LEFT_ALT   Action.PRESS
(xkeysnail)  send Key.RIGHT_CTRL Action.RELEASE
(user)       send Key.LEFT_ALT   Action.RELEASE
```

So the difference here is that we press the <kbd>ctrl</kbd> key before releasing <kbd>alt</kbd>, so will not trigger apps like Firefox to show hide the menu when <kbd>alt+f</kbd> is used, and a single press and release of the <kbd>alt</kbd> key will still show the menu as their normal behavior.

As far as I can observe, this is also the behavior of AutoHotKey on Windows.
