### PR TITLE
Replace `InputDevice.fn` accesses with `InputDevice.path`

### DIFF
--- a/xkeysnail/input.py
+++ b/xkeysnail/input.py
@@ -33,7 +33,7 @@ def is_keyboard_device(device):
 
 
 def print_device_list(devices):
-    device_format = '{1.fn:<20} {1.name:<35} {1.phys}'
+    device_format = '{1.path:<20} {1.name:<35} {1.phys}'
     device_lines = [device_format.format(n, d) for n, d in enumerate(devices)]
     print('-' * len(max(device_lines, key=len)))
     print('{:<20} {:<35} {}'.format('Device', 'Name', 'Phys'))
@@ -54,7 +54,7 @@ class DeviceFilter(object):
         # Match by device path or name, if no keyboard devices specified, picks up keyboard-ish devices.
         if self.matches:
             for match in self.matches:
-                if device.fn == match or device.name == match:
+                if device.path == match or device.name == match:
                     return True
             return False
         # Exclude none keyboard devices
@@ -92,7 +92,7 @@ xkeysnail picks up keyboard-ish devices from the list below:
 
 def in_device_list(fn, devices):
     for device in devices:
-        if device.fn == fn:
+        if device.path == fn:
             return True
     return False
 
@@ -157,7 +157,7 @@ def add_new_device(devices, device_filter, inotify):
     new_devices = []
     for event in inotify.read():
         new_device = InputDevice("/dev/input/" + event.name)
-        if device_filter(new_device) and not in_device_list(new_device.fn, devices):
+        if device_filter(new_device) and not in_device_list(new_device.path, devices):
             try:
                 new_device.grab()
             except IOError:


### PR DESCRIPTION
The `fn` attribute was deprecated in evdev 1.0.0 (Jun 02, 2018), and has now been removed.